### PR TITLE
added meter API method

### DIFF
--- a/lib/resources/Actions.js
+++ b/lib/resources/Actions.js
@@ -23,4 +23,10 @@ module.exports = HyperTrackResource.extend({
     urlParams: ['id'],
   }),
 
+  meter: hypertrackMethod({
+      method: 'GET',
+      path: '/{id}/meter/',
+      urlParams: ['id'],
+    }),
+
 });


### PR DESCRIPTION
I am in the process of developing with your API for a startup. It would help me out a lot if I could use the meter API method in your node js helper library.